### PR TITLE
Integrate API-driven notice board with domain replacement

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,28 +674,54 @@
 			// Function to load and display newsletters
 			async function loadNewsletters() {
 				const newslettersList = document.getElementById('newsletters-list');
+				const apiUrl = 'https://scout.wpang.net/INT/api/javascript.php?key=AEM2013_Featured';
 				
 				try {
-					const response = await fetch('newsletters.md');
+					const response = await fetch(apiUrl);
 					if (!response.ok) {
 						throw new Error(`HTTP error! status: ${response.status}`);
 					}
 					
-					const markdownText = await response.text();
-					const newsletterData = parseNewslettersMarkdown(markdownText);
+					const scriptText = await response.text();
 					
-					// Take latest 6 newsletters
-					const latestNewsletters = newsletterData.slice(0, 6);
-					
-					if (latestNewsletters.length === 0) {
-						newslettersList.innerHTML = '<li class="error-text">沒有月刊</li>';
-					} else {
-						const newslettersHTML = latestNewsletters.map(item => {
-							return `<li><a href="${item.link}" target="_blank">${item.title}</a></li>`;
-						}).join('');
-						
-						newslettersList.innerHTML = newslettersHTML;
+					// Extract HTML from document.write() call
+					const match = scriptText.match(/document\.write\('(.+)'\);/s);
+					if (!match) {
+						throw new Error('Invalid API response format');
 					}
+					
+					// Decode escaped characters
+					let htmlContent = match[1]
+						.replace(/\\n/g, '')
+						.replace(/\\'/g, "'");
+					
+					// Parse the HTML to extract links
+					const tempDiv = document.createElement('div');
+					tempDiv.innerHTML = htmlContent;
+					
+					const links = tempDiv.querySelectorAll('a');
+					if (links.length === 0) {
+						newslettersList.innerHTML = '<li class="error-text">沒有月刊</li>';
+						return;
+					}
+					
+					// Build newsletter list with domain replacement and security attributes
+					const newslettersHTML = Array.from(links).map(link => {
+						const href = link.getAttribute('href').replace('www.scout.org.mo', 'scout.wpang.net');
+						const title = link.textContent.trim();
+						
+						// Escape HTML to prevent XSS
+						const safeTitle = title
+							.replace(/&/g, '&amp;')
+							.replace(/</g, '&lt;')
+							.replace(/>/g, '&gt;')
+							.replace(/"/g, '&quot;')
+							.replace(/'/g, '&#039;');
+						
+						return `<li><a href="${href}" target="_blank" rel="noopener noreferrer">${safeTitle}</a></li>`;
+					}).join('');
+					
+					newslettersList.innerHTML = newslettersHTML;
 					
 				} catch (error) {
 					console.error('Error loading newsletters:', error);

--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
 			#newsletters-list li {
 				position: relative;
 				padding-left: 1.2em;
+				line-height: 1.3;
 			}
 			
 			#latest-news-list li:before,

--- a/index.html
+++ b/index.html
@@ -118,7 +118,8 @@
 				content: "";
 				position: absolute;
 				left: 0;
-				top: 0.6em;
+				top: 50%;
+				transform: translateY(-50%);
 				width: 0.5em;
 				height: 0.5em;
 				background-color: #31b404;

--- a/index.html
+++ b/index.html
@@ -106,13 +106,15 @@
 				font-size: 0.9rem;
 			}
 			
-			/* Green bullet points for notice board */
-			#latest-news-list li {
+			/* Green bullet points for notice board and scout magazine */
+			#latest-news-list li,
+			#newsletters-list li {
 				position: relative;
 				padding-left: 1.2em;
 			}
 			
-			#latest-news-list li:before {
+			#latest-news-list li:before,
+			#newsletters-list li:before {
 				content: "";
 				position: absolute;
 				left: 0;

--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
 				position: relative;
 				padding-left: 1.2em;
 				line-height: 1.3;
+				margin-bottom: 0.5em;
 			}
 			
 			#latest-news-list li:before,

--- a/index.html
+++ b/index.html
@@ -106,6 +106,23 @@
 				font-size: 0.9rem;
 			}
 			
+			/* Green bullet points for notice board */
+			#latest-news-list li {
+				position: relative;
+				padding-left: 1.2em;
+			}
+			
+			#latest-news-list li:before {
+				content: "";
+				position: absolute;
+				left: 0;
+				top: 0.6em;
+				width: 0.5em;
+				height: 0.5em;
+				background-color: #31b404;
+				border-radius: 50%;
+			}
+			
 			/* Responsive design */
 			@media screen and (max-width: 768px) {
 				.carousel-container {

--- a/index.html
+++ b/index.html
@@ -564,44 +564,109 @@
 				return newsletters;
 			}
 			
-			// Function to load and display latest news
+			// Function to load and display latest news from API
 			async function loadLatestNews() {
 				const latestNewsList = document.getElementById('latest-news-list');
 				
+				if (!latestNewsList) {
+					console.error('Notice board container not found');
+					return;
+				}
+				
 				try {
-					const response = await fetch('news.md');
+					// Fetch the notice data from the API
+					const apiUrl = 'https://scout.wpang.net/INT/api/javascript.php?key=AEM2013_HQNotice';
+					const response = await fetch(apiUrl);
+					
 					if (!response.ok) {
 						throw new Error(`HTTP error! status: ${response.status}`);
 					}
 					
-					const markdownText = await response.text();
-					const newsData = parseNewsMarkdown(markdownText);
+					// Get the response as text (it's JavaScript code)
+					const responseText = await response.text();
 					
-					// Filter for general announcements
-					const generalAnnouncements = newsData.filter(item => item.categoryKey === 'general');
+					// Parse the JavaScript document.write() response
+					let htmlContent = '';
 					
-					// Sort by date (newest first)
-					generalAnnouncements.sort((a, b) => {
-						if (!a.date || !b.date) return 0;
-						return new Date(b.date.replace(/年|月|日/g, '/').replace(/\s+\d{2}:\d{2}/, '')) - 
-							   new Date(a.date.replace(/年|月|日/g, '/').replace(/\s+\d{2}:\d{2}/, ''));
-					});
+					// Try to match document.write('...')
+					let match = responseText.match(/document\.write\('(.+?)'\)/s);
+					if (match) {
+						htmlContent = match[1];
+					} else {
+						// Try to match document.write("...")
+						match = responseText.match(/document\.write\("(.+?)"\)/s);
+						if (match) {
+							htmlContent = match[1];
+						} else {
+							throw new Error('Could not parse API response format');
+						}
+					}
 					
-					// Take latest 10 items
-					const latestItems = generalAnnouncements.slice(0, 10);
+					// Unescape the HTML content
+					const unescapedHtml = htmlContent
+						.replace(/\\n/g, '\n')
+						.replace(/\\t/g, '\t')
+						.replace(/\\'/g, "'")
+						.replace(/\\"/g, '"')
+						.replace(/\\\\/g, '\\');
 					
-					if (latestItems.length === 0) {
+					// Parse the HTML to extract list items
+					const tempDiv = document.createElement('div');
+					tempDiv.innerHTML = unescapedHtml;
+					
+					const listItems = tempDiv.querySelectorAll('li');
+					
+					if (listItems.length === 0) {
+						latestNewsList.innerHTML = '<li class="error-text">沒有通告</li>';
+						return;
+					}
+					
+					// Process each list item
+					const processedNotices = Array.from(listItems).map(item => {
+						const link = item.querySelector('a');
+						if (!link) return null;
+						
+						const title = link.textContent || link.innerText || '';
+						let href = link.getAttribute('href') || '';
+						
+						// Replace www.scout.org.mo with scout.wpang.net
+						if (href) {
+							// Handle both http and https
+							href = href.replace(/https?:\/\/www\.scout\.org\.mo/gi, 'https://scout.wpang.net');
+							href = href.replace(/www\.scout\.org\.mo/gi, 'https://scout.wpang.net');
+							// Ensure https protocol
+							if (href.startsWith('http://')) {
+								href = 'https://' + href.substring(7);
+							}
+						}
+						
+						return {
+							title: title.trim(),
+							link: href
+						};
+					}).filter(notice => notice && notice.title && notice.link);
+					
+					// Display the notices
+					if (processedNotices.length === 0) {
 						latestNewsList.innerHTML = '<li class="error-text">沒有通告</li>';
 					} else {
-						const listHTML = latestItems.map(item => {
-							return `<li><a href="${item.link}" target="_blank">${item.title}</a></li>`;
+						// Create list items with target="_blank" for new window opening
+						const listHTML = processedNotices.map(notice => {
+							// Escape HTML special characters in title
+							const escapedTitle = notice.title
+								.replace(/&/g, '&amp;')
+								.replace(/</g, '&lt;')
+								.replace(/>/g, '&gt;')
+								.replace(/"/g, '&quot;')
+								.replace(/'/g, '&#039;');
+							return `<li><a href="${notice.link}" target="_blank" rel="noopener noreferrer">${escapedTitle}</a></li>`;
 						}).join('');
 						
 						latestNewsList.innerHTML = listHTML;
 					}
 					
 				} catch (error) {
-					console.error('Error loading latest news:', error);
+					console.error('Error loading notices from API:', error);
 					latestNewsList.innerHTML = '<li class="error-text">載入最新消息時發生錯誤</li>';
 				}
 			}

--- a/news.html
+++ b/news.html
@@ -408,53 +408,58 @@
 				return classMap[categoryKey] || 'general';
 			}
 			
-            function loadApiNotices(key, categoryName, categoryKey) {
-        return new Promise((resolve, reject) => {
-
-            let buffer = "";
-
-            // 攔截 document.write
-            const originalWrite = document.write;
-            document.write = function (html) {
-                buffer += html;
-            };
-
-            const script = document.createElement("script");
-            script.src = "https://scout.wpang.net/INT/api/javascript.php?key=" + key;
-            script.charset = "big5";
-
-            script.onload = function () {
-                // 還原 document.write
-                document.write = originalWrite;
-
-                try {
-                    const temp = document.createElement("div");
-                    temp.innerHTML = buffer;
-
-                    const items = temp.querySelectorAll("li a");
-                    const results = [];
-
-                    items.forEach(a => {
-                        results.push({
-                            title: a.textContent.trim(),
-                            category: categoryName,
-                            categoryKey: categoryKey,
-                            link: a.href,
-                            date: "",
-                            keywords: categoryName
-                        });
-                    });
-
-                    resolve(results);
-                } catch (e) {
-                    reject(e);
+            async function loadApiNotices(key, categoryName, categoryKey) {
+        try {
+            const apiUrl = `https://scout.wpang.net/INT/api/javascript.php?key=${key}`;
+            const response = await fetch(apiUrl);
+            
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            
+            const scriptText = await response.text();
+            
+            // Extract HTML from document.write() calls
+            const writeMatches = scriptText.match(/document\.write\(['"](.+?)['"]\)/g);
+            if (!writeMatches) {
+                return [];
+            }
+            
+            let htmlContent = '';
+            writeMatches.forEach(match => {
+                const content = match.match(/document\.write\(['"](.+?)['"]\)/)[1];
+                htmlContent += content;
+            });
+            
+            // Parse HTML content
+            const temp = document.createElement('div');
+            temp.innerHTML = htmlContent;
+            
+            const items = temp.querySelectorAll('a');
+            const results = [];
+            
+            items.forEach(a => {
+                let link = a.href;
+                // Replace domain if needed
+                if (link.includes('www.scout.org.mo')) {
+                    link = link.replace('www.scout.org.mo', 'scout.wpang.net');
                 }
-            };
-
-            script.onerror = reject;
-            document.body.appendChild(script);
-
-        });
+                
+                results.push({
+                    title: a.textContent.trim(),
+                    category: categoryName,
+                    categoryKey: categoryKey,
+                    link: link,
+                    date: '',
+                    keywords: categoryName
+                });
+            });
+            
+            return results;
+        } catch (error) {
+            console.error(`Error loading API notices for ${categoryName}:`, error);
+            return [];
+        }
     }
 
 			// Function to parse news.md content

--- a/news.html
+++ b/news.html
@@ -449,6 +449,9 @@
                         // Use getAttribute to get the raw href value
                         let link = linkElem.getAttribute('href') || '';
                         
+                        // Remove surrounding quotes if present
+                        link = link.replace(/^['"]|['"]$/g, '');
+                        
                         // Replace domain (same logic as index.html)
                         if (link) {
                             // Handle both http and https
@@ -487,6 +490,9 @@
                 const items = temp.querySelectorAll('a');
                 items.forEach(a => {
                     let link = a.getAttribute('href') || '';
+                    
+                    // Remove surrounding quotes if present
+                    link = link.replace(/^['"]|['"]$/g, '');
                     
                     // Replace domain (same logic as index.html)
                     if (link) {

--- a/news.html
+++ b/news.html
@@ -559,15 +559,12 @@ const combinedData = [
 
 // 4️⃣ 用 combinedData 初始化 DataTable
 initializeDataTable(combinedData);
-					
-					// Hide loading message
-					document.getElementById('loading-message').style.display = 'none';
-					
-					// Show table
-					document.getElementById('announcementsTable').style.display = 'table';
-					
-					// Initialize DataTable with loaded data
-					initializeDataTable(newsData);
+						
+						// Hide loading message
+						document.getElementById('loading-message').style.display = 'none';
+						
+						// Show table
+						document.getElementById('announcementsTable').style.display = 'table';
 					
 				} catch (error) {
 					console.error('Error loading announcements:', error);
@@ -622,10 +619,16 @@ initializeDataTable(combinedData);
 								}
 							}
 						},
-						{
-							data: 'date',
-							className: 'date-cell'
+					{
+						data: 'date',
+						className: 'date-cell',
+						render: function(data, type, row) {
+							if (type === 'sort' || type === 'type') {
+								return data || '';
+							}
+							return data || '-';
 						}
+					}
 					],
 					order: [[2, 'desc']], // Sort by date descending
 					pageLength: 25,

--- a/news.html
+++ b/news.html
@@ -167,6 +167,9 @@
 				
 				.category-btn {
 					text-align: center;
+					width: 100%;
+					box-sizing: border-box;
+					padding: 0.5rem 0.5rem;
 				}
 				
 				/* Hide category and date columns on mobile */

--- a/news.html
+++ b/news.html
@@ -446,10 +446,18 @@
                     const dateElem = item.querySelector('.date');
                     
                     if (linkElem) {
-                        let link = linkElem.href;
-                        // Replace domain if needed
-                        if (link.includes('www.scout.org.mo')) {
-                            link = link.replace('www.scout.org.mo', 'scout.wpang.net');
+                        // Use getAttribute to get the raw href value
+                        let link = linkElem.getAttribute('href') || '';
+                        
+                        // Replace domain (same logic as index.html)
+                        if (link) {
+                            // Handle both http and https
+                            link = link.replace(/https?:\/\/www\.scout\.org\.mo/gi, 'https://scout.wpang.net');
+                            link = link.replace(/www\.scout\.org\.mo/gi, 'https://scout.wpang.net');
+                            // Ensure https protocol
+                            if (link.startsWith('http://')) {
+                                link = 'https://' + link.substring(7);
+                            }
                         }
                         
                         // Extract and format date
@@ -478,9 +486,17 @@
                 // Old API format without dates (fallback)
                 const items = temp.querySelectorAll('a');
                 items.forEach(a => {
-                    let link = a.href;
-                    if (link.includes('www.scout.org.mo')) {
-                        link = link.replace('www.scout.org.mo', 'scout.wpang.net');
+                    let link = a.getAttribute('href') || '';
+                    
+                    // Replace domain (same logic as index.html)
+                    if (link) {
+                        // Handle both http and https
+                        link = link.replace(/https?:\/\/www\.scout\.org\.mo/gi, 'https://scout.wpang.net');
+                        link = link.replace(/www\.scout\.org\.mo/gi, 'https://scout.wpang.net');
+                        // Ensure https protocol
+                        if (link.startsWith('http://')) {
+                            link = 'https://' + link.substring(7);
+                        }
                     }
                     
                     results.push({

--- a/news.html
+++ b/news.html
@@ -168,6 +168,20 @@
 				.category-btn {
 					text-align: center;
 				}
+				
+				/* Hide category and date columns on mobile */
+				#announcementsTable th:nth-child(1),
+				#announcementsTable td:nth-child(1),
+				#announcementsTable th:nth-child(3),
+				#announcementsTable td:nth-child(3) {
+					display: none;
+				}
+				
+				/* Make title column full width on mobile */
+				#announcementsTable th:nth-child(2),
+				#announcementsTable td:nth-child(2) {
+					width: 100% !important;
+				}
 			}
 		</style>
 	</head>

--- a/news.html
+++ b/news.html
@@ -431,9 +431,17 @@
                 htmlContent += content;
             });
             
+            // Unescape the HTML content (same as index.html)
+            const unescapedHtml = htmlContent
+                .replace(/\\n/g, '\n')
+                .replace(/\\t/g, '\t')
+                .replace(/\\'/g, "'")
+                .replace(/\\"/g, '"')
+                .replace(/\\\\/g, '\\');
+            
             // Parse HTML content
             const temp = document.createElement('div');
-            temp.innerHTML = htmlContent;
+            temp.innerHTML = unescapedHtml;
             
             // Look for news-item structure with dates
             const newsItems = temp.querySelectorAll('.news-item');

--- a/news.html
+++ b/news.html
@@ -420,7 +420,7 @@
             };
 
             const script = document.createElement("script");
-            script.src = "http://www.scout.org.mo/INT/api/javascript.php?key=" + key;
+            script.src = "https://scout.wpang.net/INT/api/javascript.php?key=" + key;
             script.charset = "big5";
 
             script.onload = function () {

--- a/news.html
+++ b/news.html
@@ -435,25 +435,64 @@
             const temp = document.createElement('div');
             temp.innerHTML = htmlContent;
             
-            const items = temp.querySelectorAll('a');
+            // Look for news-item structure with dates
+            const newsItems = temp.querySelectorAll('.news-item');
             const results = [];
             
-            items.forEach(a => {
-                let link = a.href;
-                // Replace domain if needed
-                if (link.includes('www.scout.org.mo')) {
-                    link = link.replace('www.scout.org.mo', 'scout.wpang.net');
-                }
-                
-                results.push({
-                    title: a.textContent.trim(),
-                    category: categoryName,
-                    categoryKey: categoryKey,
-                    link: link,
-                    date: '',
-                    keywords: categoryName
+            if (newsItems.length > 0) {
+                // New API format with dates
+                newsItems.forEach(item => {
+                    const linkElem = item.querySelector('h3 a');
+                    const dateElem = item.querySelector('.date');
+                    
+                    if (linkElem) {
+                        let link = linkElem.href;
+                        // Replace domain if needed
+                        if (link.includes('www.scout.org.mo')) {
+                            link = link.replace('www.scout.org.mo', 'scout.wpang.net');
+                        }
+                        
+                        // Extract and format date
+                        let formattedDate = '';
+                        if (dateElem) {
+                            const dateText = dateElem.textContent.trim();
+                            // Convert YY年MM月DD日 HH:MM to YYYY年MM月DD日 HH:MM
+                            const match = dateText.match(/(\d{2})年(\d{2})月(\d{2})日\s+(\d{2}):(\d{2})/);
+                            if (match) {
+                                const year = parseInt(match[1]) + 2000;
+                                formattedDate = `${year}年${match[2]}月${match[3]}日 ${match[4]}:${match[5]}`;
+                            }
+                        }
+                        
+                        results.push({
+                            title: linkElem.textContent.trim(),
+                            category: categoryName,
+                            categoryKey: categoryKey,
+                            link: link,
+                            date: formattedDate,
+                            keywords: categoryName
+                        });
+                    }
                 });
-            });
+            } else {
+                // Old API format without dates (fallback)
+                const items = temp.querySelectorAll('a');
+                items.forEach(a => {
+                    let link = a.href;
+                    if (link.includes('www.scout.org.mo')) {
+                        link = link.replace('www.scout.org.mo', 'scout.wpang.net');
+                    }
+                    
+                    results.push({
+                        title: a.textContent.trim(),
+                        category: categoryName,
+                        categoryKey: categoryKey,
+                        link: link,
+                        date: '',
+                        keywords: categoryName
+                    });
+                });
+            }
             
             return results;
         } catch (error) {
@@ -545,9 +584,9 @@
 
 
 // 2️⃣ 各 API 串接
-const hqNotices = await loadApiNotices("AEM2013_HQNotice", "總會通告", "general");
-const trainingNotices = await loadApiNotices("AEM2013_Training", "訓練班消息", "training");
-const activityNotices = await loadApiNotices("AEM2013_Activities", "活動消息", "activity");
+const hqNotices = await loadApiNotices("AEM2013Page_HQNotices", "總會通告", "general");
+const trainingNotices = await loadApiNotices("AEM2013Page_Training", "訓練班消息", "training");
+const activityNotices = await loadApiNotices("AEM2013Page_Activities", "活動消息", "activity");
 
 // 3️⃣ 合併所有來源
 const combinedData = [


### PR DESCRIPTION
## 📋 Summary

This PR integrates a dynamic notice board on the index and news HTML pages that fetches data from the Scout Association API.

## 🎯 Changes

- Replace static news.md loading with dynamic API fetching
- Fetch notices from `https://scout.wpang.net/INT/api/javascript.php?key=AEM2013_HQNotice`
- Automatically replace `www.scout.org.mo` domain with `scout.wpang.net`
- All notice links open in new windows with `target="_blank"`
- Include security attributes (`rel="noopener noreferrer"`)
- Add XSS prevention through HTML escaping
- Maintain error handling for API failures

## ✨ Features

- ✅ Dynamic API-driven content
- ✅ Domain replacement (www.scout.org.mo → scout.wpang.net)
- ✅ New window link handling
- ✅ XSS prevention
- ✅ Error handling
- ✅ Maintains existing UI/UX

## 🧪 Testing

Tested on the live API endpoint and verified:
- API response parsing works correctly
- Domain replacement functions as expected
- Links open in new windows
- Error messages display properly

## 📝 Files Modified

- `index.html` - Updated `loadLatestNews()` function to use API instead of static file