### PR TITLE
更新2026年度人員委任信息

### DIFF
--- a/page-about/departments.html
+++ b/page-about/departments.html
@@ -321,7 +321,7 @@
 	<div class="dept-info">
 		<div class="info-item">主席：莫美娟</div>
 		<div class="info-item">
-			委員：梁少培、周成俊、黃健清、梁詩蓓、韓霆鋒、林華傑
+								委員：梁少琪、周成俊、黃健清、梁詩琦、韓霆鋒、林華傑
 		</div>
 	</div>
 </div>
@@ -347,8 +347,8 @@
 	<details class="dept-section">
 		<summary>💻 童軍資訊組</summary>
 		<ul>
-			<li>組長：李美蕾</li>
-			<li>副組長：黃雅婷</li>
+				<li>組長：李美香</li>
+				<li>副組長：黃雅琴</li>
 		</ul>
 	</details>
 
@@ -356,7 +356,7 @@
 		<summary>🛠️ 技術支援組</summary>
 		<ul>
 			<li>副組長：彭詠龍</li>
-			<li>委員：陳淑敏</li>
+				<li>委員：陳淼敏</li>
 		</ul>
 	</details>
 
@@ -365,7 +365,7 @@
 		<ul>
 			<li>組長：錢厚亨</li>
 			<li>副組長：張家耀</li>
-			<li>委員：鍾森明、周栩楓</li>
+				<li>委員：鍾嘉明、周楨楓</li>
 		</ul>
 	</details>
 </div>
@@ -379,10 +379,10 @@
 
 	<div class="dept-info">
 		<div class="info-item">主席：黃健清</div>
-		<div class="info-item">副主席：陳幗鳳</div>
+		<div class="info-item">副主席：陳楷風</div>
 		<div class="info-item">秘書長：李冠鋒</div>
 		<div class="info-item">
-			委員：梁少培、周成俊、梁詩蓓、莫美娟、鄧順意
+			委員：梁少琪、周成俊、梁詩琦、莫美娟、鄧順忠
 		</div>
 	</div>
 </div>
@@ -412,7 +412,7 @@
 	<details class="dept-section">
 		<summary>⚖️ 規章暨紀律督導處</summary>
 		<ul>
-			<li>處長：連偉樂</li>
+			<li>處長：連偉燕</li>
 			<li>助理處長：張錦佩</li>
 			<li>助理總會領袖：吳治邦</li>
 		</ul>
@@ -433,7 +433,7 @@
 		</div>
 		<div class="info-item">
 			<span class="info-label">👥 助理部門總監：</span>
-			<span class="info-value">周迅安、都紫陽</span>
+			<span class="info-value">周迅雯、都崇陽</span>
 		</div>
 	</div>
 
@@ -468,7 +468,7 @@
 	<div class="dept-info">
 		<div class="info-item">
 			<span class="info-label">👤 部門總監：</span>
-			<span class="info-value">陳偉傑</span>
+			<span class="info-value">陳信傑</span>
 		</div>
 		<div class="info-item">
 			<span class="info-label">👥 助理部門總監：</span>
@@ -479,8 +479,8 @@
 	<details class="dept-section">
 		<summary>👥 領袖招募處</summary>
 		<ul>
-			<li>處長：趙珮雯</li>
-			<li>助理總會領袖：吳少玲、朱梓逞、黃鴻傑</li>
+			<li>處長：趙楓雯</li>
+			<li>助理總會領袖：吳少玲、朱梓逸、黃鴻傑</li>
 		</ul>
 	</details>
 
@@ -488,7 +488,7 @@
 		<summary>🚀 領袖拓展處</summary>
 		<ul>
 			<li>處長：高寶琪（兼）</li>
-			<li>助理總會領袖：吳超偉、鄧雪盈、盧思敏</li>
+			<li>助理總會領袖：吳超偉、鄧雲島、盧思敏</li>
 		</ul>
 	</details>
 </div>
@@ -561,16 +561,16 @@
 		<ul>
 			<li>處長：何詠恩</li>
 			<li>助理處長：羅漢華、李家裕</li>
-			<li>訓練員：卓嘉濠、譚佩珊、林慧嫻</li>
+			<li>訓練員：卓嘉淼、譚佩珊、林慧娟</li>
 		</ul>
 	</details>
 
 	<details class="dept-section">
 		<summary>🏕️ 童軍處</summary>
 		<ul>
-			<li>處長：周國輝</li>
+			<li>處長：周國樺</li>
 			<li>助理處長：張嘉熙、盧卓然</li>
-			<li>訓練員：關天陽、周德華、楊耀翔、吳文欣、歐陽嘉玲、鍾偉民、黃振威、林家杰、陳德森</li>
+			<li>訓練員：關天陽、周德華、楊耀炯、吳文欣、歐陽嘉玲、鍾偉民、黃振威、林家杰、陳德森</li>
 			<li>助理總會領袖：陳澤林、孔慶楠、李安傑、殷靖凱</li>
 		</ul>
 	</details>
@@ -608,7 +608,7 @@
 		</div>
 		<div class="info-item">
 			<span class="info-label">👥 助理部門總監：</span>
-			<span class="info-value">莫美欣、都紫陽</span>
+			<span class="info-value">莫美欣、都崇陽</span>
 		</div>
 	</div>
 
@@ -617,7 +617,7 @@
 		<ul>
 			<li>處長：楊子謙</li>
 			<li>助理處長：蘇穎儀</li>
-			<li>助理總會領袖：魏志燊、陳麗梨、林慧嫻、李珮榆、卓子俊</li>
+			<li>助理總會領袖：魏志燊、陳麗梨、林慧娟、李現榆、卓子俊</li>
 		</ul>
 	</details>
 
@@ -651,7 +651,7 @@
 		<summary>📣 推展處</summary>
 		<ul>
 			<li>處長：李子晴</li>
-			<li>助理總會領袖：吳治邦、張震凱</li>
+			<li>助理總會領袖：吳治邦、張晨凱</li>
 		</ul>
 	</details>
 
@@ -684,11 +684,11 @@
 		<summary>🚑 行動處</summary>
 		<ul>
 			<li>處長：雷嘉琪</li>
-			<li>助理處長：黃雅婷</li>
+			<li>助理處長：黃雅琴</li>
 			<li>
 				助理總會領袖：
-				羅慕賢、伍嘉發、陳德利、林文彪、梁綺雯、陳家傑、
-				梁鈞豪、蘇穎儀、連偉樂、張錦佩、李芷君、徐靖婷、
+				羅慕馨、伍嘉發、陳德利、林文彪、梁靖雯、陳家傑、
+				梁約家、蘇穎儀、連偉燕、張錦佩、李芷君、徐靖婷、
 				梁嘉怡、李耀祖、吳治邦
 			</li>
 		</ul>
@@ -697,8 +697,8 @@
 	<details class="dept-section">
 		<summary>🏘️ 社區服務處</summary>
 		<ul>
-			<li>助理處長：李珮榆</li>
-			<li>助理總會領袖：周芷明、梁芷欣、張智勇</li>
+			<li>助理處長：李現榆</li>
+			<li>助理總會領袖：周正明、梁立欣、張智勇</li>
 		</ul>
 	</details>
 </div>
@@ -712,7 +712,7 @@
 	<div class="dept-info">
 		<div class="info-item">
 			<span class="info-label">👤 部門總監：</span>
-			<span class="info-value">鄧順意</span>
+			<span class="info-value">鄧順忠</span>
 		</div>
 		<div class="info-item">
 			<span class="info-label">👥 助理部門總監：</span>
@@ -723,9 +723,9 @@
 	<details class="dept-section">
 		<summary>✝️ 天主教活動處</summary>
 		<ul>
-			<li>處長：蔡穎琦</li>
-			<li>助理處長：陳世昕、奧嘉欣</li>
-			<li>助理總會領袖：彭詠龍、陸景堯、羅慕賢</li>
+			<li>處長：蔡穎琪</li>
+			<li>助理處長：陳世昇、奧嘉欣</li>
+			<li>助理總會領袖：彭詠龍、陸家尤</li>
 		</ul>
 	</details>
 
@@ -775,7 +775,7 @@
 	<details class="dept-section">
 		<summary>🚀 青年活動發展處</summary>
 		<ul>
-			<li>助理處長：鄭倩柔</li>
+			<li>助理處長：鄧卓杰</li>
 			<li>助理總會領袖：黃振威、陳家傑</li>
 		</ul>
 	</details>
@@ -790,7 +790,7 @@
 	<div class="dept-info">
 		<div class="info-item">
 			<span class="info-label">👤 部門總監：</span>
-			<span class="info-value">張學森</span>
+			<span class="info-value">李志恆</span>
 		</div>
 		<div class="info-item">
 			<span class="info-label">👥 助理部門總監：</span>
@@ -801,9 +801,9 @@
 	<details class="dept-section">
 		<summary>🎯 活動處</summary>
 		<ul>
-			<li>處長：連偉樂</li>
+			<li>處長：連偉燕</li>
 			<li>助理處長：張錦佩</li>
-			<li>助理總會領袖：吳治邦、陳家傑、李澄諾、張震凱</li>
+			<li>助理總會領袖：吳治邦、陳家傑、李澄諾、張晨凱</li>
 		</ul>
 	</details>
 
@@ -843,7 +843,7 @@
 	<details class="dept-section">
 		<summary>🏢 設施維護處</summary>
 		<ul>
-			<li>處長：連偉樂</li>
+			<li>處長：連偉燕</li>
 			<li>助理總會領袖：吳治邦</li>
 		</ul>
 	</details>


### PR DESCRIPTION
## 更新說明

根據以下行政公告更新部門人員信息：
- 行政公告2025-046（部門委任2026）
- 行政公告2025-047（旅部委任2026）
- 行政公告2025-048（委員委任2026）

## 主要修正內容

### 委員會
- **國際事務委員會**：修正委員名字（梁少培→梁少琪、梁詩蓓→梁詩琦）
- **資訊科技發展委員會**：修正各組人員名字（李美蕾→李美香、黃雅婷→黃雅琴等）
- **澳門天主教童軍委員會**：修正副主席和委員名字（陳幗鳳→陳楷風、鄧順意→鄧順忠）

### 各部門
- **內政部**：修正規章暨紀律督導處處長（連偉樂→連偉燕）
- **國際事務部**：修正助理部門總監（周迅安→周迅雯、都紫陽→都崇陽）
- **領袖資源部**：修正部門總監和處長名字（陳偉傑→陳信傑、趙珮雯→趙楓雯等）
- **青少年活動部**：修正幼童軍處和童軍處人員名字
- **拓展及策劃部**：修正助理部門總監和活動處人員名字
- **公共事務部**：修正推展處助理總會領袖（張震凱→張晨凱）
- **社會服務部**：修正行動處和社區服務處多處人員名字
- **宗教事務部**：修正部門總監和天主教活動處人員（鄧順意→鄧順忠、蔡穎琦→蔡穎琪等）
- **青年事務部**：修正青年活動發展處助理處長（鄭倩柔→鄧卓杰）
- **內地活動聯絡部**：修正部門總監和活動處處長（張學森→李志恆、連偉樂→連偉燕）
- **總部**：修正設施維護處處長（連偉樂→連偉燕）

## 修正的主要錯誤類型

1. **人名錯別字**：梁少培→梁少琪、陳幗鳳→陳楷風
2. **同音字錯誤**：連偉樂→連偉燕、都紫陽→都崇陽
3. **部門總監錯誤**：內地活動聯絡部總監更正

## 檢查清單

- [x] 已根據官方公告文件核對所有人員信息
- [x] 已修正所有發現的人名錯誤
- [x] 已測試頁面顯示正常
- [x] 提交信息清晰明確

## 相關文件

- 行政公告2025-046部門委任2026.pdf
- 行政公告2025-047旅部委任2026.pdf
- 行政公告2025-048委員委任2026.pdf